### PR TITLE
Show Mainframe SDK version in upper-right corner

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -112,7 +112,6 @@ class App extends Component<{}, State> {
             update: this.updateActiveNote,
             save: this.saveNote,
             delete: this.deleteNote,
-            mf: new MainframeSDK(),
           }}>
           <Home
             initial={this.state.initial}

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -4,6 +4,7 @@ import React, { Component, type Node } from 'react'
 import { ThemeProvider } from 'styled-components/native'
 import _ from 'lodash'
 import uuidv4 from 'uuid/v4'
+import MainframeSDK from '@mainframe/sdk'
 
 import { type Note } from '../types'
 
@@ -28,6 +29,7 @@ class App extends Component<{}, State> {
       date: new Date().getTime(),
     },
     notes: _.toArray(NOTES),
+    sessionKey: '',
   }
 
   componentDidMount() {
@@ -103,6 +105,7 @@ class App extends Component<{}, State> {
             update: this.updateActiveNote,
             save: this.saveNote,
             delete: this.deleteNote,
+            mf: new MainframeSDK(),
           }}>
           <Home />
         </Provider>

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -19,7 +19,6 @@ type State = {
   note: Note,
   notes: Array<Note>,
   mf: MainframeSDK,
-  sessionKey: string,
   apiVersion: string,
   initial: boolean,
 }
@@ -34,7 +33,6 @@ class App extends Component<{}, State> {
     },
     notes: _.toArray(NOTES),
     mf: new MainframeSDK(),
-    sessionKey: '',
     apiVersion: '',
     initial: false,
   }

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -6,7 +6,6 @@ import styled from 'styled-components/native'
 import LeftNav from './LeftNav'
 import MainArea from './MainArea'
 import InitialState from './InitialState'
-import applyContext from '../hocs/Context'
 
 type Props = {
   initial: boolean,
@@ -43,4 +42,4 @@ class Home extends Component<Props> {
   }
 }
 
-export default applyContext(Home)
+export default Home

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -6,9 +6,16 @@ import styled from 'styled-components/native'
 import LeftNav from './LeftNav'
 import MainArea from './MainArea'
 import InitialState from './InitialState'
+import MainframeSDK from '@mainframe/sdk'
+import applyContext from '../hocs/Context'
 
 type State = {
   initial: boolean,
+  apiVersion: string,
+}
+
+type Props = {
+  mf: MainframeSDK,
 }
 
 const Root = styled.View`
@@ -17,17 +24,29 @@ const Root = styled.View`
   flex: 1;
   flex-direction: row;
 `
-class Home extends Component<{}, State> {
+
+const SdkVersion = styled.Text`
+  position: fixed;
+  z-index: 1;
+  right: 0;
+  padding: 5px;
+`
+
+class Home extends Component<Props, State> {
   state = {
     initial: true,
+    apiVersion: '',
   }
 
-  componentDidMount() {
+  async componentDidMount() {
     // there will likely be a better/ additional deciding factor here
     // once integrated w/ swarm
     if (localStorage.getItem('notes')) {
       this.setState({ initial: false })
     }
+    console.log("this.props", this.props)
+    this.setState({apiVersion: await this.props.mf.apiVersion()})
+
   }
 
   setInitialFalse = () => {
@@ -38,6 +57,7 @@ class Home extends Component<{}, State> {
     return (
       <Root>
         <LeftNav />
+        <SdkVersion>Mainframe SDK Version: {this.state.apiVersion}</SdkVersion>
         {this.state.initial ? (
           <InitialState setInitialFalse={this.setInitialFalse} />
         ) : (
@@ -48,4 +68,4 @@ class Home extends Component<{}, State> {
   }
 }
 
-export default Home
+export default applyContext(Home)


### PR DESCRIPTION
- first example of using MainframeSDK in Noted is calling the `apiVersion` call
- the location and styling of the version number should probably change
- there are currently no other API calls in the SDK that are useful to Noted