### PR TITLE
Use Morpheus UI for Buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "not op_mini all"
   ],
   "dependencies": {
+    "@morpheus-ui/core": "^0.0.3",
+    "@morpheus-ui/fonts": "^0.0.1",
     "draft-js": "^0.10.5",
     "lodash": "^4.17.11",
     "react": "^16.6.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "not op_mini all"
   ],
   "dependencies": {
-    "@morpheus-ui/core": "^0.0.3",
+    "@morpheus-ui/core": "^0.0.4",
     "@morpheus-ui/fonts": "^0.0.1",
     "draft-js": "^0.10.5",
     "lodash": "^4.17.11",

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,10 +1,12 @@
 // @flow
 
 import React, { Component, type Node } from 'react'
-import { ThemeProvider } from 'styled-components/native'
+import { ThemeProvider as NativeThemeProvider } from 'styled-components/native'
+import { ThemeProvider as ComponentsThemeProvider } from '@morpheus-ui/core'
 import _ from 'lodash'
 import uuidv4 from 'uuid/v4'
 import MainframeSDK from '@mainframe/sdk'
+import '@morpheus-ui/fonts'
 
 import { getNotes, setNotes, archiveNotes, getArchive } from '../localStorage'
 import { type Note } from '../types'
@@ -170,27 +172,29 @@ class App extends Component<{}, State> {
 
   render(): Node {
     return (
-      <ThemeProvider theme={theme}>
-        <Provider
-          value={{
-            ...this.state,
-            getFolders: this.getFolderArray,
-            updateFolders: this.updateFolderNames,
-            updateArchive: this.archiveNote,
-            archive: this.state.archive,
-            key: this.state.note.key,
-            update: this.updateActiveNote,
-            save: this.saveNote,
-            delete: this.deleteNote,
-            getNote: this.getNoteFromKey,
-          }}>
-          <Home
-            initial={this.state.initial}
-            apiVersion={this.state.apiVersion}
-            setInitialFalse={this.setInitialFalse}
-          />
-        </Provider>
-      </ThemeProvider>
+      <NativeThemeProvider theme={theme.native}>
+        <ComponentsThemeProvider theme={theme.components} >
+          <Provider
+            value={{
+              ...this.state,
+              getFolders: this.getFolderArray,
+              updateFolders: this.updateFolderNames,
+              updateArchive: this.archiveNote,
+              archive: this.state.archive,
+              key: this.state.note.key,
+              update: this.updateActiveNote,
+              save: this.saveNote,
+              delete: this.deleteNote,
+              getNote: this.getNoteFromKey,
+            }}>
+            <Home
+              initial={this.state.initial}
+              apiVersion={this.state.apiVersion}
+              setInitialFalse={this.setInitialFalse}
+            />
+          </Provider>
+        </ComponentsThemeProvider>
+      </NativeThemeProvider>
     )
   }
 }

--- a/src/components/LeftNav.js
+++ b/src/components/LeftNav.js
@@ -3,7 +3,7 @@
 import React, { Component } from 'react'
 import styled, { css } from 'styled-components/native'
 import { View } from 'react-native-web'
-import { Button, TextField } from '@morpheus-ui/core'
+import { Button } from '@morpheus-ui/core'
 import uuidv4 from 'uuid/v4'
 import { type Note } from '../types'
 import applyContext from '../hocs/Context'
@@ -53,8 +53,7 @@ const SearchContainer = styled.View`
   align-items: center;
 `
 
-const NewButton = styled.Button`
-  flex: 1;
+const NewButtonContainer = styled.View`
   margin-bottom: 100px;
 `
 
@@ -144,17 +143,18 @@ class LeftNav extends Component<Props, State> {
       <Container>
         <SearchContainer>
           <SearchBar data={this.props.notes} />
-          <Button
-            onPress={() =>
-              this.props.update({
-                key: uuidv4(),
-                date: new Date().getTime(),
-                folder: '',
-              })
-            }
-            title="Add new note"
-            trace={true}
-          />
+          <NewButtonContainer>
+            <Button
+              onPress={() =>
+                this.props.update({
+                  key: uuidv4(),
+                  date: new Date().getTime(),
+                  folder: '',
+                })
+              }
+              title="Add new note"
+            />
+          </NewButtonContainer>
         </SearchContainer>
         <TitleText>Your Notes</TitleText>
         <Button title="Add a new folder" onPress={this.addFolder} />

--- a/src/components/LeftNav.js
+++ b/src/components/LeftNav.js
@@ -3,6 +3,7 @@
 import React, { Component } from 'react'
 import styled, { css } from 'styled-components/native'
 import { View } from 'react-native-web'
+import { Button, TextField } from '@morpheus-ui/core'
 import uuidv4 from 'uuid/v4'
 import { type Note } from '../types'
 import applyContext from '../hocs/Context'
@@ -148,7 +149,7 @@ class LeftNav extends Component<Props, State> {
       <Container>
         <SearchContainer>
           <SearchBar data={this.props.notes} />
-          <NewButton
+          <Button
             onPress={() =>
               this.props.update({
                 key: uuidv4(),
@@ -156,10 +157,11 @@ class LeftNav extends Component<Props, State> {
               })
             }
             title="Add new note"
+            trace={true}
           />
         </SearchContainer>
         <TitleText>Your Notes</TitleText>
-        <NewButton title="Add a new folder" onPress={this.addFolder} />
+        <Button title="Add a new folder" onPress={this.addFolder} />
         {Object.values(this.props.getFolders()).map(
           (subArray: Array<Note>, index: number) => {
             return (

--- a/src/components/MainArea.js
+++ b/src/components/MainArea.js
@@ -2,6 +2,7 @@
 
 import React, { Component } from 'react'
 import styled from 'styled-components/native'
+import { Button } from '@morpheus-ui/core'
 import { Editor } from 'react-draft-wysiwyg'
 import {
   EditorState,
@@ -58,14 +59,6 @@ const ButtonContainer = styled.View`
   justify-content: space-between;
 `
 
-const SaveButton = styled.Button`
-  flex: 1;
-`
-
-const DeleteButton = styled.Button`
-  flex: 1;
-`
-
 class MainArea extends Component<Props, State> {
   interval: IntervalID
 
@@ -119,8 +112,8 @@ class MainArea extends Component<Props, State> {
           onChangeText={this.onTitleChange}
         />
         <ButtonContainer>
-          <SaveButton onPress={this.props.save} title="Save" />
-          <DeleteButton onPress={this.props.delete} title="Delete" />
+          <Button onPress={this.props.save} title="Save" />
+          <Button onPress={this.props.delete} title="Delete" />
         </ButtonContainer>
         <Text>
           {this.state.autosaved &&

--- a/src/theme.js
+++ b/src/theme.js
@@ -13,7 +13,12 @@ export default {
     Button: {
       default: {
         backgroundColor: colors.lightBlue,
+        borderColor: colors.lightBlue,
         titleColor: colors.white,
+
+        backgroundHoverColor: colors.white,
+        borderHoverColor: colors.white,
+        titleHoverColor: colors.darkGray,
       }
     },
   },

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,4 +1,4 @@
-export default {
+const colors = {
   white: '#fff',
   blue: '#1f3464',
   lightBlue: '#00a7e7',
@@ -6,6 +6,19 @@ export default {
   lightGray: '#f1f1f1',
   gray: '#f2f2f2',
   darkGray: '#232323',
+}
 
-  spacing: '20px',
+export default {
+  components: {
+    Button: {
+      default: {
+        backgroundColor: colors.lightBlue,
+        titleColor: colors.white,
+      }
+    },
+  },
+  native: {
+    ...colors,
+    spacing: '20px',
+  }
 }


### PR DESCRIPTION
- Leaves `styled-components/native` ThemeProvider intact, while also providing new Morpheus UI theming.
- Replaces styled buttons with Morpheus UI buttons.