### PR TITLE
Added build/run instructions using the development sdk/launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 [![CircleCI](https://circleci.com/gh/MainframeHQ/noted.svg?style=svg)](https://circleci.com/gh/MainframeHQ/noted)
 # noted
 Noted is a simple dApp for composing and organizing text notes in MainframeOS
+
+## Build/run instructions
+
+- Inside the `js-mainframe` project, at the `/packages/sdk` directory, run `npm link`.
+- Run the mainframe launcher program with `npm run dev` and follow the setup instructions.
+- Inside the root of this project, run `npm link @mainframe/sdk`.
+- Build the project with `npm run build`.
+- The first time this project is run, create a new application and add the `/build` directory as the content path.


### PR DESCRIPTION
I tried to run this example dapp together with the development build of sdk/launcher to get a taste of mainframe platform and I missed having some documentation, so I added it to README.